### PR TITLE
More Jenkinsfile fixes, use go 1.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,14 +22,14 @@ pipeline {
             }
             steps {
                 withEnv(["VAULT_HELPER_BUILD_VERSION=1.0.${env.BUILD_NUMBER}"]) {
-                    dir("${workspace}/vault-helper") {
+                    dir("${workspace}") {
                         habitat task: 'build', directory: '.', origin: env.HAB_ORIGIN, bldrUrl: env.HAB_BLDR_URL
                     }
                 }
                 withCredentials([string(credentialsId: 'depot-token', variable: 'HAB_AUTH_TOKEN')]) {
-                    habitat task: 'upload', lastBuildFile: "${workspace}/vault-helper/results/last_build.env", authToken: env.HAB_AUTH_TOKEN, bldrUrl: env.HAB_BLDR_URL
+                    habitat task: 'upload', lastBuildFile: "${workspace}/results/last_build.env", authToken: env.HAB_AUTH_TOKEN, bldrUrl: env.HAB_BLDR_URL
                 }
-                dir("${workspace}/vault-helper") {
+                dir("${workspace}") {
                     sh 'hab studio rm'
                 }
             }

--- a/habitat/clean.sh
+++ b/habitat/clean.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# This cleans out the local build env to make sure it's in a pristine state
+#
+# Run INSIDE habitat studio
+#
+
+#
+# Remove all 'bin' files
+#
+if [ -d "bin" ]; then
+    rm -f bin/*
+fi
+
+#
+# Remove all 'pkg' files/folders
+#
+if [ -d "pkg" ]; then
+    rm -rf pkg/*
+fi
+
+#
+# Remove local results dir
+#
+if [ -d "results" ]; then
+    rm -rf results
+fi
+
+#
+# Remove go-dep vendored dirs
+#
+if [ -d "src" ] ; then
+    for X in $( ls -1d src/* ); do
+        if [ -d "${X}/vendor" ]; then
+            rm -rf ${X}/vendor
+        fi
+    done
+fi

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,7 +2,7 @@ pkg_name=vault-helper
 pkg_origin=indellient
 pkg_version="0.1.0"
 pkg_bin_dirs=(bin)
-pkg_build_deps=(core/go/1.10.3 core/which core/gcc core/curl core/git)
+pkg_build_deps=(core/go core/which core/gcc core/curl core/git)
 
 do_download(){
     return 0
@@ -80,6 +80,7 @@ do_build() {
 
     # Perform debug build with -race
     build_line "Performing debug build(s) ..."
+    build_line "    --> go build -race ${OS} ${ARCH} ${BINARY_NAME}-linux-amd64-race ..."
     GOOS=linux GOARCH=amd64 go build             \
         -o="bin/${BINARY_NAME}-linux-amd64-race" \
         -pkgdir="./pkg"                          \

--- a/src/cli/main.go
+++ b/src/cli/main.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, args []string) {
 	switch kingpin.MustParse(app.Parse(args[1:])) {
 	case tCreate.FullCommand():
 		logger.SetLoggingLevel(*logLevel)
-		logger.Infof("Create token ...", *addr)
+		logger.Infof("Create token ...")
 		fmt.Println(vault.NewVaultClient(ctx, GetEnvValue(EnvVaultAddr, *addr), GetBoolEnvValue(EnvVaultInsecure, *insecure)).CreateToken(GetEnvValue(EnvVaultRoleId, *tCreateRoleId), GetEnvValue(EnvVaultRoleId, *tCreateSecretId)))
 
 	case tRenew.FullCommand():


### PR DESCRIPTION
Jenkinsfile fixes, add a new clean.sh which can be run from inside studio to get pristine local build environment. Update plan.sh to use go 1.11, fix a logger.Infof() call.