### PR TITLE
Pull in glibc for pkg build & pkg runtime deps.  Bump version, run gometalinter only on `src` dir.

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,8 +1,9 @@
 pkg_name=vault-helper
 pkg_origin=indellient
-pkg_version="0.1.3"
+pkg_version="0.1.4"
 pkg_bin_dirs=(bin)
-pkg_build_deps=(core/go core/which core/gcc core/curl core/git)
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/go core/which core/gcc core/glibc core/curl core/git)
 
 do_download(){
     return 0
@@ -65,7 +66,7 @@ do_build() {
 
     # Run gometalinter.v2 --fast
     build_line "Running gometalinter in $(pwd) ..."
-    bin/gometalinter --fast
+    bin/gometalinter --fast src
 
     # Perform unit tests
     build_line "Running go unit tests ..."


### PR DESCRIPTION
## Proof

```
kmott@kmott-sabayon /tmp/foobar $ hab pkg install bluepipeline/vault-helper
» Installing bluepipeline/vault-helper
☁ Determining latest version of bluepipeline/vault-helper in the 'stable' channel
☛ Verifying bluepipeline/vault-helper/0.1.4/20190529202633
☛ Verifying core/glibc/2.27/20190115002733
→ Using core/linux-headers/4.17.12/20190115002705
✓ Installed core/glibc/2.27/20190115002733
✓ Installed bluepipeline/vault-helper/0.1.4/20190529202633
★ Install of bluepipeline/vault-helper/0.1.4/20190529202633 complete with 2 new packages installed.

kmott@kmott-sabayon /tmp/foobar $ ldd $( hab pkg path bluepipeline/vault-helper )/bin/vault-helper
	linux-vdso.so.1 (0x00007ffd9419c000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f5730baf000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f57309dc000)
	/hab/pkgs/core/glibc/2.27/20190115002733/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f5730c4c000)

kmott@kmott-sabayon /tmp/foobar $ ls -lah /hab/pkgs/core/glibc/2.27/20190115002733/lib/ld-linux-x86-64.so.2
lrwxrwxrwx 1 kmott kmott 10 Jan 14 16:36 /hab/pkgs/core/glibc/2.27/20190115002733/lib/ld-linux-x86-64.so.2 -> ld-2.27.so
```